### PR TITLE
Create resumes table migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ middleware.ts               # Route protection
 
 Table: `resumes` (id, user_id, title, template, content jsonb, created_at, updated_at)
 RLS enabled — users can only access their own resumes.
-Supabase project ref: `tzpgsfaxorayraazbosm` (Frankfurt region)
+Supabase project ref: `tcivruueyqbgpwlniawz` (eu-west-1)
 
 ## Environment Variables
 

--- a/supabase/migrations/20260323_create_resumes_table.sql
+++ b/supabase/migrations/20260323_create_resumes_table.sql
@@ -1,0 +1,13 @@
+create table resumes (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade not null,
+  title text not null default 'Untitled Resume',
+  template text not null default 'general',
+  content jsonb not null default '{}',
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+alter table resumes enable row level security;
+
+create policy "Users can CRUD own resumes" on resumes for all using (auth.uid() = user_id);


### PR DESCRIPTION
This pull request added the first database schema for the earlier account based version.

* Created the resumes table migration
* Added row level security policy setup
* Prepared stored resume data for the initial authenticated workflow

Closes #4
Closes #5
