### PR TITLE
Define resume TypeScript types

### DIFF
--- a/lib/types/resume.ts
+++ b/lib/types/resume.ts
@@ -1,0 +1,61 @@
+/* ------------------------------------------------------------------ */
+/*  Resume data types – shared across the entire project              */
+/*  Matches the `content` JSONB column in the `resumes` table         */
+/* ------------------------------------------------------------------ */
+
+export interface PersonalInfo {
+  fullName: string;
+  email: string;
+  phone: string;
+  location: string;
+  website: string;
+  linkedin: string;
+  summary: string;
+}
+
+export interface ExperienceItem {
+  id: string;
+  company: string;
+  position: string;
+  location: string;
+  startDate: string;
+  endDate: string;
+  current: boolean;
+  description: string;
+}
+
+export interface EducationItem {
+  id: string;
+  institution: string;
+  degree: string;
+  field: string;
+  location: string;
+  startDate: string;
+  endDate: string;
+  gpa: string;
+  description: string;
+}
+
+export interface SkillGroup {
+  id: string;
+  category: string;
+  items: string[];
+}
+
+export interface ProjectItem {
+  id: string;
+  name: string;
+  url: string;
+  startDate: string;
+  endDate: string;
+  description: string;
+  technologies: string[];
+}
+
+export interface ResumeContent {
+  personal: PersonalInfo;
+  experience: ExperienceItem[];
+  education: EducationItem[];
+  skills: SkillGroup[];
+  projects: ProjectItem[];
+}


### PR DESCRIPTION
This pull request added the first shared data model for resumes.

* Defined TypeScript interfaces for resume content
* Made editor and storage code share the same data shape
* Prepared section level implementation work with clearer types

Close #12