### PR TITLE
Improve collapsed section click areas

### DIFF
--- a/components/editor/FormPanel.tsx
+++ b/components/editor/FormPanel.tsx
@@ -130,10 +130,10 @@ function CollapsibleSection({
   return (
     <section className="section-card rounded-lg border border-border">
       {/* Header */}
-      <div className="section-header flex items-center justify-between px-4 py-3">
+      <div className="section-header flex items-stretch justify-between px-4">
         <button
           type="button"
-          className="flex flex-1 cursor-pointer items-center gap-2 text-sm font-semibold tracking-tight transition-colors hover:text-foreground"
+          className="flex flex-1 cursor-pointer items-center gap-2 py-3 text-sm font-semibold tracking-tight transition-colors hover:text-foreground"
           onClick={() => setCollapsed(!collapsed)}
         >
           {meta.label}

--- a/components/editor/sections/EducationSection.tsx
+++ b/components/editor/sections/EducationSection.tsx
@@ -146,10 +146,10 @@ function EducationBlock({
   return (
     <div className="entry-card rounded-lg border border-border">
       {/* Block header — clickable to collapse, always visible */}
-      <div className="entry-header flex items-center justify-between px-3 py-2">
+      <div className="entry-header flex items-stretch justify-between px-3">
         <button
           type="button"
-          className="flex flex-1 cursor-pointer items-center gap-1 text-left"
+          className="flex flex-1 cursor-pointer items-center gap-1 py-2 text-left"
           onClick={() => setCollapsed(!collapsed)}
         >
           <ChevronRight className={`size-3 text-muted-foreground transition-transform duration-200 ${collapsed ? "" : "rotate-90"}`} />

--- a/components/editor/sections/ExperienceSection.tsx
+++ b/components/editor/sections/ExperienceSection.tsx
@@ -126,10 +126,10 @@ function ExperienceBlock({
   return (
     <div className="entry-card rounded-lg border border-border">
       {/* Block header — clickable to collapse */}
-      <div className="entry-header flex items-center justify-between px-3 py-2">
+      <div className="entry-header flex items-stretch justify-between px-3">
         <button
           type="button"
-          className="flex flex-1 cursor-pointer items-center gap-1 text-left"
+          className="flex flex-1 cursor-pointer items-center gap-1 py-2 text-left"
           onClick={() => setCollapsed(!collapsed)}
         >
           <ChevronRight className={`size-3 text-muted-foreground transition-transform duration-200 ${collapsed ? "" : "rotate-90"}`} />

--- a/components/editor/sections/ProjectsSection.tsx
+++ b/components/editor/sections/ProjectsSection.tsx
@@ -136,10 +136,10 @@ function ProjectBlock({
   return (
     <div className="entry-card rounded-lg border border-border">
       {/* Block header — clickable to collapse */}
-      <div className="entry-header flex items-center justify-between px-3 py-2">
+      <div className="entry-header flex items-stretch justify-between px-3">
         <button
           type="button"
-          className="flex flex-1 cursor-pointer items-center gap-1 text-left"
+          className="flex flex-1 cursor-pointer items-center gap-1 py-2 text-left"
           onClick={() => setCollapsed(!collapsed)}
         >
           <ChevronRight className={`size-3 text-muted-foreground transition-transform duration-200 ${collapsed ? "" : "rotate-90"}`} />


### PR DESCRIPTION
This pull request made collapsed section headers easier to use.

* Expanded the clickable area of collapsed headers
* Reduced missed clicks during section navigation
* Improved everyday editor usability

Close #51