### PR TITLE
Fix phantom preview page at page boundary

### DIFF
--- a/components/academic-cv/PreviewPanel.tsx
+++ b/components/academic-cv/PreviewPanel.tsx
@@ -1,7 +1,13 @@
 "use client";
 
+import { useRef, useState, useLayoutEffect } from "react";
 import type { AcademicCVContent, ResumeLanguage } from "@/lib/types/academic-cv";
 import { AcademicTemplate } from "./templates/AcademicTemplate";
+
+const PAGE_H = 1123;
+const TOP = 36;
+const BOTTOM = 48;
+const CONTENT_H = PAGE_H - TOP - BOTTOM;
 
 interface PreviewPanelProps {
   content: AcademicCVContent;
@@ -9,10 +15,70 @@ interface PreviewPanelProps {
 }
 
 export function PreviewPanel({ content, language }: PreviewPanelProps) {
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [numPages, setNumPages] = useState(1);
+
+  useLayoutEffect(() => {
+    const el = measureRef.current;
+    if (!el) return;
+
+    const calc = () =>
+      Math.max(1, Math.ceil((el.scrollHeight - TOP - BOTTOM - 8) / CONTENT_H));
+
+    setNumPages(calc());
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const ro = new ResizeObserver(() => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        setNumPages(calc());
+        timer = null;
+      }, 400);
+    });
+    ro.observe(el);
+
+    return () => {
+      ro.disconnect();
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
   return (
     <div className="flex flex-1 items-start justify-center overflow-y-auto bg-muted/50 p-8">
-      <div className="preview-a4 overflow-hidden rounded-sm border border-border shadow-lg">
-        <AcademicTemplate content={content} language={language} />
+      {/* Hidden export target — captured by lib/export.ts via .preview-a4 > div */}
+      <div style={{ position: "fixed", left: "-9999px", top: 0, width: "794px", pointerEvents: "none" }}>
+        <div className="preview-a4">
+          <div ref={measureRef}>
+            <AcademicTemplate content={content} language={language} />
+          </div>
+        </div>
+      </div>
+
+      {/* Visible paginated pages */}
+      <div className="flex flex-col items-center gap-4">
+        {Array.from({ length: numPages }).map((_, i) => (
+          <div
+            key={i}
+            className="overflow-hidden rounded-sm border border-border bg-white shadow-lg transition-colors duration-200 hover:border-black"
+            style={{ width: "794px", height: `${PAGE_H}px`, flexShrink: 0, position: "relative" }}
+          >
+            {/* Inset window preserves TOP/BOTTOM margins on every page */}
+            <div
+              style={{
+                position: "absolute",
+                top: TOP,
+                left: 0,
+                right: 0,
+                height: CONTENT_H,
+                overflow: "hidden",
+              }}
+            >
+              <div style={{ transform: `translateY(${-(TOP + i * CONTENT_H)}px)` }}>
+                <AcademicTemplate content={content} language={language} />
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/components/cover-letter/PreviewPanel.tsx
+++ b/components/cover-letter/PreviewPanel.tsx
@@ -1,17 +1,83 @@
 "use client";
 
+import { useRef, useState, useLayoutEffect } from "react";
 import type { CoverLetterContent } from "@/lib/types/cover-letter";
 import { CoverLetterTemplate } from "./templates/CoverLetterTemplate";
+
+const PAGE_H = 1123;
+const TOP = 36;
+const BOTTOM = 48;
+const CONTENT_H = PAGE_H - TOP - BOTTOM;
 
 interface Props {
   content: CoverLetterContent;
 }
 
 export function PreviewPanel({ content }: Props) {
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [numPages, setNumPages] = useState(1);
+
+  useLayoutEffect(() => {
+    const el = measureRef.current;
+    if (!el) return;
+
+    const calc = () =>
+      Math.max(1, Math.ceil((el.scrollHeight - TOP - BOTTOM - 8) / CONTENT_H));
+
+    setNumPages(calc());
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const ro = new ResizeObserver(() => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        setNumPages(calc());
+        timer = null;
+      }, 400);
+    });
+    ro.observe(el);
+
+    return () => {
+      ro.disconnect();
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
   return (
     <div className="flex flex-1 items-start justify-center overflow-y-auto bg-muted/50 p-8">
-      <div className="preview-a4 overflow-hidden rounded-sm border border-border shadow-lg">
-        <CoverLetterTemplate content={content} />
+      {/* Hidden export target — captured by lib/export.ts via .preview-a4 > div */}
+      <div style={{ position: "fixed", left: "-9999px", top: 0, width: "794px", pointerEvents: "none" }}>
+        <div className="preview-a4">
+          <div ref={measureRef}>
+            <CoverLetterTemplate content={content} />
+          </div>
+        </div>
+      </div>
+
+      {/* Visible paginated pages */}
+      <div className="flex flex-col items-center gap-4">
+        {Array.from({ length: numPages }).map((_, i) => (
+          <div
+            key={i}
+            className="overflow-hidden rounded-sm border border-border bg-white shadow-lg transition-colors duration-200 hover:border-black"
+            style={{ width: "794px", height: `${PAGE_H}px`, flexShrink: 0, position: "relative" }}
+          >
+            {/* Inset window preserves TOP/BOTTOM margins on every page */}
+            <div
+              style={{
+                position: "absolute",
+                top: TOP,
+                left: 0,
+                right: 0,
+                height: CONTENT_H,
+                overflow: "hidden",
+              }}
+            >
+              <div style={{ transform: `translateY(${-(TOP + i * CONTENT_H)}px)` }}>
+                <CoverLetterTemplate content={content} />
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/components/editor/PreviewPanel.tsx
+++ b/components/editor/PreviewPanel.tsx
@@ -1,7 +1,13 @@
 "use client";
 
+import { useRef, useState, useLayoutEffect } from "react";
 import type { ResumeContent, ResumeLanguage } from "@/lib/types/resume";
 import { GeneralTemplate } from "./templates/GeneralTemplate";
+
+const PAGE_H = 1123;
+const TOP = 36;
+const BOTTOM = 48;
+const CONTENT_H = PAGE_H - TOP - BOTTOM;
 
 interface PreviewPanelProps {
   content: ResumeContent;
@@ -9,10 +15,73 @@ interface PreviewPanelProps {
 }
 
 export function PreviewPanel({ content, language }: PreviewPanelProps) {
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [numPages, setNumPages] = useState(1);
+
+  useLayoutEffect(() => {
+    const el = measureRef.current;
+    if (!el) return;
+
+    const calc = () =>
+      Math.max(1, Math.ceil((el.scrollHeight - TOP - BOTTOM - 8) / CONTENT_H));
+
+    // Set immediately on mount so the initial page count is correct
+    setNumPages(calc());
+
+    // Debounce subsequent updates so page count doesn't flicker while the user
+    // is actively typing in the last field of a page
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const ro = new ResizeObserver(() => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        setNumPages(calc());
+        timer = null;
+      }, 400);
+    });
+    ro.observe(el);
+
+    return () => {
+      ro.disconnect();
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
   return (
     <div className="flex flex-1 items-start justify-center overflow-y-auto bg-muted/50 p-8">
-      <div className="preview-a4 overflow-hidden rounded-sm border border-border shadow-lg">
-        <GeneralTemplate content={content} language={language} />
+      {/* Hidden export target — captured by lib/export.ts via .preview-a4 > div */}
+      <div style={{ position: "fixed", left: "-9999px", top: 0, width: "794px", pointerEvents: "none" }}>
+        <div className="preview-a4">
+          <div ref={measureRef}>
+            <GeneralTemplate content={content} language={language} />
+          </div>
+        </div>
+      </div>
+
+      {/* Visible paginated pages */}
+      <div className="flex flex-col items-center gap-4">
+        {Array.from({ length: numPages }).map((_, i) => (
+          <div
+            key={i}
+            className="overflow-hidden rounded-sm border border-border bg-white shadow-lg transition-colors duration-200 hover:border-black"
+            style={{ width: "794px", height: `${PAGE_H}px`, flexShrink: 0, position: "relative" }}
+          >
+            {/* Inset window preserves TOP/BOTTOM margins on every page */}
+            <div
+              style={{
+                position: "absolute",
+                top: TOP,
+                left: 0,
+                right: 0,
+                height: CONTENT_H,
+                overflow: "hidden",
+              }}
+            >
+              <div style={{ transform: `translateY(${-(TOP + i * CONTENT_H)}px)` }}>
+                <GeneralTemplate content={content} language={language} />
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
This pull request fixed a pagination edge case in the document preview.

* Handled false extra pages near page boundaries
* Reduced layout noise from scroll height rounding
* Kept export previews closer to the visible document flow

Close #88