### PR TITLE
Fix logo loading on GitHub Pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
-import logoImg from "@/public/logo-text-horizontal.png";
 import { ArrowRight, FileText, GraduationCap, Mail, Star } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -30,6 +29,8 @@ import {
   TITLE_MAX,
 } from "@/lib/defaults";
 import type { ResumeTemplate, ResumeLanguage } from "@/lib/types/resume";
+
+const LOGO_SRC = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/logo-text-horizontal.png`;
 
 function GithubIcon({ className }: { className?: string }) {
   return (
@@ -251,7 +252,7 @@ export default function EntryPage() {
       <header className="relative z-10 flex items-center justify-between px-8 py-5 lg:px-12">
         <Link href="/" className="inline-flex items-center bg-transparent" aria-label="CVForge home">
           <Image
-            src={logoImg}
+            src={LOGO_SRC}
             alt="CVForge"
             width={1262}
             height={329}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
+import logoImg from "@/public/logo-text-horizontal.png";
 import { ArrowRight, FileText, GraduationCap, Mail, Star } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -250,7 +251,7 @@ export default function EntryPage() {
       <header className="relative z-10 flex items-center justify-between px-8 py-5 lg:px-12">
         <Link href="/" className="inline-flex items-center bg-transparent" aria-label="CVForge home">
           <Image
-            src="/logo-text-horizontal.png"
+            src={logoImg}
             alt="CVForge"
             width={1262}
             height={329}


### PR DESCRIPTION
This pull request fixed logo loading in the static deployment environment.

* Replaced a string image path with a static import
* Made logo resolution compatible with the configured base path
* Improved branding reliability on GitHub Pages